### PR TITLE
Create fetch_big.t

### DIFF
--- a/t/fetch_big.t
+++ b/t/fetch_big.t
@@ -1,0 +1,41 @@
+use Time::HiRes qw(time);
+use Test::More tests => 2;
+
+BEGIN { use_ok('Set::IntervalTree') };
+
+use strict;
+use warnings;
+
+my $tree = Set::IntervalTree->new;
+
+
+my $start_number = 42;
+my $inter_range_interval = 10;
+my $max_range_interval = 1000;
+my $max_num = 0xffffffff;
+my $cur_number = $start_number;
+my $iterations = 1;
+
+while($cur_number <= $max_num && $iterations < 100000){
+    my $range_end = $cur_number+int(rand($max_range_interval))+1;
+    $tree->insert($cur_number."-".$range_end, $cur_number, $range_end);
+    $cur_number = $range_end+int(rand($inter_range_interval))+1;
+    $iterations++;
+
+}
+
+my $start = int(rand(5000000));
+my $end = $start + int(rand(50));
+
+my $start_measure = time();
+
+for (my $i = 0; $i < 10000; $i++){
+    my $node = $tree->fetch( $start, $end );
+}
+
+my $end_measure = time();
+
+my $elapsed_time = ($end_measure - $start_measure);
+print "Time elapsed was ".$elapsed_time."\n";
+
+cmp_ok($elapsed_time, '<=', 1.0, "We should do 10,000 fetches in less than a second");


### PR DESCRIPTION
Added test to measure performance of fetch in big interval tree.

When the above test is run on my PC with Intel Core i7 on latest version  the result of the test for elapsed time result is about 15-18seconds
```
$ git co master
$ dzil test
...
t/author-pod-syntax.t .. ok
t/fetch-nearest.t ...... ok
t/fetch_big.t .......... 2/2
#   Failed test 'We should do 10,000 fetches in less than a second'
#   at t/fetch_big.t line 41.
#     '10.0522201061249'
#         <=
#     '1'
# Looks like you failed 1 test of 2.
t/fetch_big.t .......... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests
t/fetch_window.t ....... ok
t/Set-IntervalTree.t ... ok
Test Summary Report
-------------------
t/fetch_big.t        (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
Files=5, Tests=17, 10 wallclock secs ( 0.02 usr  0.01 sys + 10.19 cusr  0.07 csys = 10.29 CPU)
Result: FAIL
Failed 1/5 test programs. 1/17 subtests failed.
make: *** [Makefile:1018: test_dynamic] Error 255
error running make test
```

When I checkout manually e2f149c807267b4ffeecdc818285bf1d400abb56 the result is usually about 10ms.
```
$ perl fetch_big.t
1..2
ok 1 - use Set::IntervalTree;
Time elapsed was 0.00767803192138672
ok 2 - We should do 10,000 fetches in less than a second
```

As far as I could see the problem appeared in 909461adb024412278de36305fd6fc342be9a496, but since it is a fix plus refactor and my C++ skills  are very very basic, I figured you will be much faster and efficient at spotting and fixing the issue.